### PR TITLE
replace single quotes with double quotes in concurrently script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:client:dev": "webpack --config=webpack",
     "build:client:prod": "webpack --env.production --config=webpack",
     "development:client": "webpack-dev-server --config webpack --hot --inline",
-    "development": "concurrently -k -c 'blue,green' -p [{name}] -n 'proxy,dev-server' 'yarn run proxy:debug' 'yarn run development:client'"
+    "development": "concurrently -k -c \"blue,green\" -p [{name}] -n \"proxy,dev-server\" \"yarn run proxy:debug\" \"yarn run development:client\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Single quotes doesn't seem to work in Windows. 

Not sure if this will still work in OS X or Linux